### PR TITLE
fix: allow any argument name

### DIFF
--- a/dbus_next/introspection.py
+++ b/dbus_next/introspection.py
@@ -32,9 +32,6 @@ class Arg:
                  signature: Union[SignatureType, str],
                  direction: List[ArgDirection] = None,
                  name: str = None):
-        if name is not None:
-            assert_member_name_valid(name)
-
         type_ = None
         if type(signature) is SignatureType:
             type_ = signature


### PR DESCRIPTION
D-Bus spec do not requires `name` of method arguments
to be a valid member name.

- https://dbus.freedesktop.org/doc/dbus-specification.html#introspection-format
- https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names-member

For real world example, interface `org.gtk.Application` has a method
`Activate` of which argument names `platform-data`.
