### PR TITLE
fix: allow any property name

### DIFF
--- a/dbus_next/introspection.py
+++ b/dbus_next/introspection.py
@@ -278,9 +278,7 @@ class Property:
                  name: str,
                  signature: str,
                  access: PropertyAccess = PropertyAccess.READWRITE,
-                annotations: Optional[dict[str, str]] = None):
-        assert_member_name_valid(name)
-
+                 annotations: Optional[dict[str, str]] = None):
         tree = SignatureTree._get(signature)
         if len(tree.types) != 1:
             raise InvalidIntrospectionError(


### PR DESCRIPTION
According to D-Bus specification, property name is allow to not be a
valid member name.

> ...
> Member (i.e. method or signal) names:
> ...

https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names-member
